### PR TITLE
Improve streaming robustness and add cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ require('llm').setup({
 
 Triggers the LLM assistant. You can pass an optional `replace` flag to replace the current selection with the LLM's response. The prompt is either the visually selected text or the file content up to the cursor if no selection is made.
 
+**`cancel()`**
+
+Stops the current request if one is running.
+
 **`create_llm_md()`**
 
 Creates a new `llm.md` file in the current working directory, where you can write questions or prompts for the LLM.


### PR DESCRIPTION
## Summary
- add sanitization to remove special multiplication symbols from streamed content
- improve SSE parsing with error handling, token limit messages, and stderr capture
- allow cancelling an in-flight request and document the new cancel() helper

## Testing
- `luacheck lua/llm.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb6dc3f7c832bbb5437c765a4eabf