### PR TITLE
Add context helper and tests

### DIFF
--- a/lua/llm/context.lua
+++ b/lua/llm/context.lua
@@ -1,0 +1,51 @@
+local M = {}
+
+local entries = {}
+
+local function estimate_tokens(text)
+  return math.ceil(#text / 4)
+end
+
+function M.clear()
+  entries = {}
+end
+
+function M.get_context_entries()
+  return entries
+end
+
+function M.add_context(text, symbol)
+  table.insert(entries, {
+    text = text,
+    symbol = symbol or "",
+    tokens = estimate_tokens(text),
+  })
+end
+
+function M.add_context_file(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local text = table.concat(lines, "\n")
+  local symbols = {}
+  local ok, result = pcall(vim.lsp.buf_request_sync, bufnr, "textDocument/documentSymbol", nil, 1000)
+  if ok and type(result) == "table" then
+    for _, res in pairs(result) do
+      if res.result then
+        for _, item in ipairs(res.result) do
+          if item.name then
+            table.insert(symbols, item.name)
+          end
+        end
+      end
+    end
+  end
+  local symbol_str = table.concat(symbols, ", ")
+  table.insert(entries, {
+    text = text,
+    symbol = symbol_str,
+    tokens = estimate_tokens(text),
+  })
+end
+
+return M
+

--- a/tests/context_spec.lua
+++ b/tests/context_spec.lua
@@ -1,0 +1,35 @@
+local context = require('llm.context')
+
+describe('context helpers', function()
+  before_each(function()
+    context.clear()
+  end)
+
+  it('collects buffer and manual context', function()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {
+      'hello',
+      'world',
+    })
+
+    local symbols = { { result = { { name = 'MySymbol' } } } }
+    local orig = vim.lsp.buf_request_sync
+    vim.lsp.buf_request_sync = function() return symbols end
+
+    context.add_context_file(bufnr)
+
+    vim.lsp.buf_request_sync = orig
+
+    context.add_context('extra text', 'Extra')
+
+    local entries = context.get_context_entries()
+
+    assert.equals('hello\nworld', entries[1].text)
+    assert.equals('MySymbol', entries[1].symbol)
+    assert.equals(math.ceil(#('hello\nworld') / 4), entries[1].tokens)
+
+    assert.equals('extra text', entries[2].text)
+    assert.equals('Extra', entries[2].symbol)
+    assert.equals(math.ceil(#('extra text') / 4), entries[2].tokens)
+  end)
+end)

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,2 @@
+vim.cmd('set rtp+=' .. vim.fn.getcwd())
+vim.cmd('packadd plenary.nvim')


### PR DESCRIPTION
## Summary
- add context module to collect buffer text and token estimates
- test context addition using stubbed LSP symbols

## Testing
- `nvim --headless -c "lua require('plenary.test_harness').test_directory('tests', { minimal_init = 'tests/minimal_init.lua' })"` *(fails: command not found: nvim)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aeba80c838832bb6e2137d4c5cbc7e