### PR TITLE
Silence curl progress output in streaming requests

### DIFF
--- a/lua/llm.lua
+++ b/lua/llm.lua
@@ -522,6 +522,7 @@ Key capabilities:
         })
 
         local args = {
+                "-sS",
                 "-N",
                 "-X",
                 "POST",


### PR DESCRIPTION
## Summary
- silence curl progress output for streaming prompts to avoid stderr noise and failures

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ffcb61c70832ba94634384d0d9b91)